### PR TITLE
Administer Real Time Indexing service

### DIFF
--- a/111-fix-prcs-features-validation.md
+++ b/111-fix-prcs-features-validation.md
@@ -1,6 +1,6 @@
 # Fix `pt_prcs_domain.rb` validation logic
 
-> _Note_:  This error has been around since the advent of DPK.  Apply patch if you want to explicitly enable/disable PPM
+> _Note_:  This error has been around since the advent of DPK.  Apply patch if you want to explicitly enable/disable `PPM` or `RTI`
 
 ```
 Error: Parameter feature_settings failed on Pt_prcs_domain[PRCSDOM]: Validate method failed for class feature_settings: undefined local variable or method `prcs_feature' for #<Puppet::Type::Pt_prcs_domain::Feature_settings:0x0000000009d50ee0>

--- a/111-fix-prcs-features-validation.patch
+++ b/111-fix-prcs-features-validation.patch
@@ -7,7 +7,7 @@ index fa87206..dab766a 100644
  
          prcs_features =
 -          [ "MSTRSRV", "APPENG", "KIOSK", "DOMAIN_GW", "SERVER_EVENTS" ]
-+          [ "MSTRSRV", "APPENG", "PPM", "DOMAIN_GW", "SERVER_EVENTS" ]  # <umaritimus dpkpatch/>
++          [ "MSTRSRV", "APPENG", "PPM", "RTI", "DOMAIN_GW", "SERVER_EVENTS" ]  # <umaritimus dpkpatch/>
  
          value = [value] unless value.is_a? Array
  


### PR DESCRIPTION
Process Scheduler feature validation doesn't account for RTI.
It's delivered as enabled by default.  However, this commit
allows dpk user to enable/disable RTI via configuration.

Signed-off-by: Andy Dorfman <umaritimus@users.noreply.github.com>

Closes #1 